### PR TITLE
Replication updates

### DIFF
--- a/_index.yml
+++ b/_index.yml
@@ -3,7 +3,7 @@ indexpage:
   title: Amazon FSx for NetApp ONTAP management
   lead: Amazon FSx for NetApp ONTAP brings the full capabilities of ONTAP to a native AWS managed service delivering a consistent hybrid cloud experience. This documentation describes how to manage FSx for ONTAP in the NetApp Console.
   summary: Amazon FSx for NetApp ONTAP brings the full capabilities of ONTAP to a native AWS managed service delivering a consistent hybrid cloud experience. This documentation describes how to manage FSx for ONTAP in the NetApp Console.
-  keywords: amazon, fsx, netapp, ontap, bluexp, create, manage, NetApp Console
+  keywords: amazon, fsx, netapp, ontap, create, manage, NetApp Console
   tiles: 
     - title: Get started
       links:

--- a/requirements/task-setting-up-permissions-fsx.adoc
+++ b/requirements/task-setting-up-permissions-fsx.adoc
@@ -1,7 +1,7 @@
 ---
 sidebar: sidebar
 permalink: requirements/task-setting-up-permissions-fsx.html
-keywords: fsx for ontap, iam, user role, permissions, credentials, bluexp
+keywords: fsx for ontap, iam, user role, permissions, credentials
 summary: To create or manage an FSx for ONTAP working environment, you need to add AWS credentials in the NetApp Console by providing the ARN of an IAM role that gives the permissions needed to create an FSx for ONTAP system from the NetApp Console.
 ---
 

--- a/start/concept-fsx-aws.adoc
+++ b/start/concept-fsx-aws.adoc
@@ -1,7 +1,7 @@
 ---
 sidebar: sidebar
 permalink: start/concept-fsx-aws.html
-keywords: Amazon FSx for NetApp ONTAP, volumes, aws, access key, secret key, cloud manager, NetApp Console, bluexp
+keywords: Amazon FSx for NetApp ONTAP, volumes, aws, access key, secret key, cloud manager, NetApp Console
 summary: "Amazon FSx for NetApp ONTAP is a fully managed service allowing customers to launch and run file systems powered by NetApp's ONTAP storage operating system."
 ---
 
@@ -23,7 +23,7 @@ The NetApp Console provides centralized management of NetApp storage and data se
  
 You don't need a license or subscription to start using NetApp Console and you only incur charges when you need to deploy Console agents in your cloud to ensure connectivity to your storage systems or NetApp data services. However, some NetApp data services accessible from the Console are licensed or subscription-based.
 
-Learn more about the https://docs.netapp.com/us-en/bluexp-setup-admin/concept-overview.html[NetApp Console].
+Learn more about the https://docs.netapp.com/us-en/console-setup-admin/concept-overview.html[NetApp Console].
 
 == Using FSx for ONTAP from the NetApp Console
 From the NetApp Console systems page, you can create and discover FSx for ONTAP systems and use System Manager and other NetApp services. If you want to manage FSx for ONTAP systems and workloads running on Amazon FSx for NetApp ONTAP, use https://docs.netapp.com/us-en/workload-fsx-ontap/index.html[NetApp Workload Factory^].

--- a/start/task-getting-started-fsx.adoc
+++ b/start/task-getting-started-fsx.adoc
@@ -1,7 +1,7 @@
 ---
 sidebar: sidebar
 permalink: start/task-getting-started-fsx.html
-keywords: Amazon FSx for NetApp ONTAP, fsx, netapp, data fabric, hybrid cloud, cloud, public cloud, networking, vpc, quick, getting started, install, installing, deploy, deploying, setup, setting up, launching, requirements, prerequisites, netapp console, get started, permissions, policy, iam policy, policies, attach, iam user, access key, secret key, keys, sign up, cloud manager, create, bluexp
+keywords: Amazon FSx for NetApp ONTAP, fsx, netapp, data fabric, hybrid cloud, cloud, public cloud, networking, vpc, quick, getting started, install, installing, deploy, deploying, setup, setting up, launching, requirements, prerequisites, netapp console, get started, permissions, policy, iam policy, policies, attach, iam user, access key, secret key, keys, sign up, cloud manager, create
 summary: "Get started with Amazon FSx for NetApp ONTAP in the NetApp Console by adding credentials, creating a Console agent or link, and by creating or discovering a file system."
 ---
 

--- a/support/task-get-help.adoc
+++ b/support/task-get-help.adoc
@@ -1,7 +1,7 @@
 ---
 sidebar: sidebar
 permalink: support/task-get-help.html
-keywords: help, ticket, open support case, support, netapp support, technical support, call support, phone number, open ticket, web ticket, open an issue, NetApp Console, bluexp
+keywords: help, ticket, open support case, support, netapp support, technical support, call support, phone number, open ticket, web ticket, open an issue, NetApp Console
 summary: NetApp provides support for the NetApp Console in a variety of ways. Extensive free self-support options are available 24x7, such as knowledgebase (KB) articles and a community forum. Your support registration includes remote technical support via web ticketing.
 ---
 

--- a/support/task-support-registration.adoc
+++ b/support/task-support-registration.adoc
@@ -1,7 +1,7 @@
 ---
 sidebar: sidebar
 permalink: support/task-support-registration.html
-keywords: support registration, register for support, support, nss account, add nss account, NetApp Console, bluexp
+keywords: support registration, register for support, support, nss account, add nss account, NetApp Console
 summary: Before you can open a support case with NetApp technical support, you need to add a NetApp Support Site account to the NetApp Console and then register for support.
 ---
 

--- a/use/task-create-fsx-system.adoc
+++ b/use/task-create-fsx-system.adoc
@@ -1,7 +1,7 @@
 ---
 sidebar: sidebar
 permalink: use/task-create-fsx-system.html
-keywords: Amazon FSx for NetApp ONTAP, fsx, volumes, create system, delete system, access key, secret key, region, working environment, availability zones, discover, storage capacity, iops, throughput, security group, security, bluexp, NetApp Console
+keywords: Amazon FSx for NetApp ONTAP, fsx, volumes, create system, delete system, access key, secret key, region, working environment, availability zones, discover, storage capacity, iops, throughput, security group, security, NetApp Console
 summary: "Create or discover an FSx for ONTAP file systems to add and manage volumes and additional data services from the NetApp Console."
 ---
 

--- a/use/task-manage-fsx-systems.adoc
+++ b/use/task-manage-fsx-systems.adoc
@@ -1,7 +1,7 @@
 ---
 sidebar: sidebar
 permalink: use/task-manage-fsx-systems.html
-keywords: amazon fsx for netapp ontap, fsx, manage fsx for ontap system, delete fsx for ontap system, remove fsx for ontap system, throughput capacity, change throughput, automatic capacity management, capacity management, storage capacity, replication, classification, sync, backup, recovery, bluexp, NetApp Console
+keywords: amazon fsx for netapp ontap, fsx, manage fsx for ontap system, delete fsx for ontap system, remove fsx for ontap system, throughput capacity, change throughput, automatic capacity management, capacity management, storage capacity, replication, classification, sync, backup, recovery, NetApp Console
 summary: After you create or discover an FSx for ONTAP system in NetApp Console, you can manage the file system and use NetApp data services that provide capabilities like backup and recovery.
 ---
 

--- a/use/task-monitor-operations.adoc
+++ b/use/task-monitor-operations.adoc
@@ -1,7 +1,7 @@
 ---
 sidebar: sidebar
 permalink: use/task-monitor-operations.html 
-keywords: monitor jobs, track jobs, monitor, track, NetApp Console, bluexp
+keywords: monitor jobs, track jobs, monitor, track, NetApp Console
 summary: "Track FSx for ONTAP operations and monitor operation progress with Tracker in NetApp Console."  
 ---
 = Monitor FSx for ONTAP operations with Tracker in NetApp Console

--- a/use/task-remove-filesystem.adoc
+++ b/use/task-remove-filesystem.adoc
@@ -1,7 +1,7 @@
 ---
 sidebar: sidebar
 permalink: use/task-remove-filesystem.html
-keywords: amazon fsx for netapp ontap, fsx for ontap, fsx, remove fsx for ontap file system, remove file system, file system, disassociate file system, bluexp, NetApp Console
+keywords: amazon fsx for netapp ontap, fsx for ontap, fsx, remove fsx for ontap file system, remove file system, file system, disassociate file system, NetApp Console
 summary: "Remove an FSx for ONTAP file system from a project in the NetApp Console." 
 ---
 

--- a/use/task-replicate-data.adoc
+++ b/use/task-replicate-data.adoc
@@ -87,11 +87,14 @@ Consider when you choose to complete this operation. Initialization can be time-
 .Steps
 . In the NetApp Console, select the menu image:workloads-menu-icon.png[The hamburger menu icon is used to navigate to workloads like storage, eda, ai, databases, vmware, and administration.] and then select *Storage*.
 
+//Rachel L: Include content comes from the workload-fsx-ontap repository.
 include::https://raw.githubusercontent.com/NetAppDocs/workload-fsx-ontap/main/_include/initialize-replication.adoc[]
 
 [start=7]
 //Rachel L: Added a hack to make the last step have a numbered step in the right order.
-. Select *Initialize*.
+. In the Initialize relationship dialog, select *Initialize*. 
++
+When the replication status shows *Idle*, the data transfer is complete. 
 
 == Step 3: Cut over replication for migration use cases 
 
@@ -126,6 +129,7 @@ Review these requirements before you begin.
 .Steps
 . In the NetApp Console, select the menu image:workloads-menu-icon.png[The hamburger menu icon is used to navigate to workloads like storage, eda, ai, databases, vmware, and administration.] and then select *Storage*.
 
+//Rachel L: Include content comes from the workload-fsx-ontap repository.
 include::https://raw.githubusercontent.com/NetAppDocs/workload-fsx-ontap/main/_include/cutover-replication.adoc[]
 
 [start=7]

--- a/use/task-replicate-data.adoc
+++ b/use/task-replicate-data.adoc
@@ -47,7 +47,7 @@ To migrate storage VM data and configuration settings, you must complete two ope
 2. <<Step 2: Initialize the replication relationship,Initialize the replication relationship>> to transfer the data from the source to the target storage system.
 3. <<Step 3: Cut over replication for migration use cases,Cut over replication for migration use cases>> to permanently migrate data and configuration settings from the source file system to the target FSx for ONTAP file system.
 
-== Step 1: Create a replication relationship
+== Step 1: Create the replication relationship
 Replicate data between two FSx for ONTAP file systems, between an on-premises ONTAP system and an FSx for ONTAP file system, or between Cloud Volumes ONTAP and an FSx for ONTAP file system.
 
 .Before you begin
@@ -149,4 +149,4 @@ After you cut over replication for migration use cases, update the following sto
 
 == Related information
 
-link:change-tiering-policy.html[Modify the tiering policy] for the target volume(s) after cutover.
+link:https://review.docs.netapp.com/us-en/workload-fsx-ontap_wa-updates/change-tiering-policy.html[Modify the tiering policy] for the target volume(s) after cutover.

--- a/use/task-replicate-data.adoc
+++ b/use/task-replicate-data.adoc
@@ -1,8 +1,8 @@
 ---
 sidebar: sidebar
 permalink: use/task-replicate-data.html
-keywords: amazon fsx for netapp ontap, fsx, manage fsx for ontap system, delete fsx for ontap system, remove fsx for ontap system, throughput capacity, change throughput, automatic capacity management, capacity management, storage capacity, replication, classification, sync, backup, recovery, bluexp, NetApp Console
-summary: After you create or discover an FSx for ONTAP system in NetApp Console, you can manage the file system and use NetApp data services that provide capabilities like backup and recovery.
+keywords: replication, replicate fsx for ontap, data protection, disaster recovery, data loss, initialize, cut over, cutover, data transfer, sync
+summary: "Create a replication relationship for an FSx for ONTAP file system to avoid data loss in case of an unforeseen disaster from the NetApp Console."
 ---
 
 = Replicate data to FSx for ONTAP in NetApp Console
@@ -12,11 +12,13 @@ summary: After you create or discover an FSx for ONTAP system in NetApp Console,
 [.lead]
 Replicate data to protect against data loss if the region where your data resides experiences a disaster. Data replication is supported between FSx for ONTAP file systems and on-premises ONTAP systems or Cloud Volumes ONTAP. 
 
-For storage VM migration, you must complete the cut over operation right after you create a replication relationship. 
+When replicating storage VM data and configuration settings, you must first create and initialize the replication relationship and then wait for the data to sync at least once before completing the cut over operation.
 
 == About this task
 
 Replication protects your data from regional disasters and supports storage VM migration.
+
+Replication includes creating and initializing a replication relationship. To set up replication, create the replication relationship. To transfer the data between the source and target storage systems, initialize the replication relationship. When migrating storage VM data and configuration settings, you must also complete the cutover operation.
 
 Replicated volumes in the target file system are data protection (DP) volumes and follow the naming format: `{OriginalVolumeName}_copy`.
 
@@ -24,13 +26,12 @@ If you replicate a source volume with immutable files, the target volume and fil
 
 [NOTE]
 ===============================
-* Replication isn't supported for block volumes using iSCSI or NVMe protocols.
-* You can replicate one source (read/write) volume or one data protection (DP) volume. Cascading replication is supported, but a third hop isn't. Learn more about link:https://review.docs.netapp.com/us-en/workload-fsx-ontap_cascade-replication/cascade-replication.html[cascading replication^].
+You can replicate one source (read/write) volume or one data protection (DP) volume. Cascading replication is supported, but a third hop isn't. Learn more about link:https://review.docs.netapp.com/us-en/workload-fsx-ontap_cascade-replication/cascade-replication.html[cascading replication^].
 ===============================
 
 === Migration use cases
  
-When you select the migration use case, you can optionally select to replicate storage VM data and configuration settings for a single storage VM. When migrating data and configuration settings simultaneously, ensure that the last replication for the volume completed in the last 24 hours. All volumes in the same storage VM must be selected to use this feature. The tiering policy for all volumes defaults to the tiering policy of the source volume, which is recommended for migration use cases.
+For migration, you can choose to replicate storage VM data and configuration settings for one storage VM. If you migrate data and configuration settings together, make sure the last replication for the volume finished within the last 24 hours. You must select all volumes in the same storage VM to use this feature. The tiering policy for all volumes defaults to the tiering policy of the source volume, which is recommended for migration use cases.
 
 Workload Factory supports migration replication between the following storage systems. 
 
@@ -38,15 +39,15 @@ Workload Factory supports migration replication between the following storage sy
 * Cloud Volumes ONTAP and FSx for ONTAP file systems
 * FSx for ONTAP and FSx for ONTAP file systems
 ** First to first generation 
-** First to second generation 
 ** Second to second generation
 
 To migrate storage VM data and configuration settings, you must complete two operations.
 
-1. <<Create a replication relationship,Create a replication relationship>>, select *Migration* as the use case and select *Replicate storage VM configuration*. 
-2. <<Cut over replication for migration use cases,Cut over replication for migration use cases>> to permanently migrate data and configuration settings from the source file system to the target FSx for ONTAP file system.
+1. <<Step 1: Create the replication relationship,Create the replication relationship>>, select *Migration* as the use case and select *Replicate storage VM configuration*.
+2. <<Step 2: Initialize the replication relationship,Initialize the replication relationship>> to transfer the data from the source to the target storage system.
+3. <<Step 3: Cut over replication for migration use cases,Cut over replication for migration use cases>> to permanently migrate data and configuration settings from the source file system to the target FSx for ONTAP file system.
 
-== Create a replication relationship
+== Step 1: Create a replication relationship
 Replicate data between two FSx for ONTAP file systems, between an on-premises ONTAP system and an FSx for ONTAP file system, or between Cloud Volumes ONTAP and an FSx for ONTAP file system.
 
 .Before you begin
@@ -74,9 +75,44 @@ The replication relationship appears in the *Replication relationships* tab in t
 
 If you created a replication relationship for migration purposes, you must cut over all the volumes and their associated storage VM to complete migration of storage VM data and configuration settings to the target FSx for ONTAP file system.
 
-== Cut over replication for migration use cases
+== Step 2: Initialize the replication relationship
 
-After creating a replication relationship for a migration use case, you must cut over replication to complete migration of storage VM data and configuration settings to a target FSx for ONTAP file system. Cutover replication permanently migrates data and storage VM configuration settings from the source file system to the target FSx for ONTAP file system. During the cutover, data gets replicated for the last time. The system deletes the source volume(s) after cutover completes. You can't undo this action. 
+Initialize a replication relationship between source and target volumes to transfer the snapshot and all data blocks in NetApp Workload Factory. 
+
+Initialization performs a _baseline_ transfer: it makes a snapshot of the source volume, then transfers the snapshot and all the data blocks it references to the target volume. 
+
+.Before you begin
+Consider when you choose to complete this operation. Initialization can be time-consuming. You might want to run the baseline transfer in off-peak hours.
+
+.Steps
+. In the NetApp Console, select the menu image:workloads-menu-icon.png[The hamburger menu icon is used to navigate to workloads like storage, eda, ai, databases, vmware, and administration.] and then select *Storage*.
+
+include::https://raw.githubusercontent.com/NetAppDocs/workload-fsx-ontap/main/_include/initialize-replication.adoc[]
+
+[start=7]
+//Rachel L: Added a hack to make the last step have a numbered step in the right order.
+. Select *Initialize*.
+
+== Step 3: Cut over replication for migration use cases 
+
+After creating the replication relationship for a migration use case, you must cut over replication to complete migration of storage VM data and configuration settings to the target FSx for ONTAP file system. Cutover replication permanently migrates data and storage VM configuration settings from the source file system to the target FSx for ONTAP file system. During the cutover, data gets replicated for the last time. The source storage VM goes offline when the cutover begins.
+
+=== Plan for the cutover operation
+Consider the following when planning for the cutover operation for migration use cases.
+
+* *Replication version support*: Source and target storage systems must have the same major ONTAP version. For example, if the source system is running ONTAP version 9.18.1, then the target system must also run a version of 9.18.1.
+
+* *Storage VM configuration settings*: The cutover operation doesn't migrate all storage VM configuration settings to the target storage VM. For example, iSCSI, broadcast-domain MTU, and DNS settings do not migrate. Update these settings manually on the target storage VM after cutover. For more details, refer to the <<Update configuration settings after cutover,Update configuration settings after cutover>> section.
+
+* *Clones*: Clones get migrated as individual volumes, and therefore, will consume more space on the target FSx for ONTAP file system. Consider deleting the clones before cutover to avoid increased capacity on the target.
+
+* *Cache volumes*: For ONTAP FlexCache 9.17.x or below. Source storage VMs that contain cache volumes aren't supported for cutover. Remove the ONTAP FlexCache relationship before cutover to avoid migration failures.
+
+* *AWS S3 access points*: Cutover replication for migration use cases isn't supported for volumes with S3 access points. Delete S3 access points from the source volume to avoid migration failures.
+
+* *ONTAP S3 configurations*: Cutover replication for migration use cases isn't supported for vservers with ONTAP S3 configurations. Remove ONTAP S3 configurations including object-store-server, buckets, users, groups, or policies on the vserver, to avoid migration failures.
+
+* *LUN serial numbers and iSCSI target IQN*: LUN serial numbers and the iSCSI target IQN change during cutover. 
 
 .Before you begin
 Review these requirements before you begin.
@@ -85,6 +121,7 @@ Review these requirements before you begin.
 * Ensure all source volumes are not serving any data before you cut over replication.
 * Ensure the data is synced between the source and target volumes before you cut over replication. 
 * The FSx for ONTAP file system you use for the replication relationship must have an associated link. link:https://docs.netapp.com/us-en/workload-fsx-ontap/create-link.html[Learn how to associate an existing link or to create and associate a new link]. After you associate the link, return to this operation.
+** The following ports must be open in the security group associated with the FSx for ONTAP file system for link connectivity: port 443 (HTTPS) and port 22 (SSH).
 
 .Steps
 . In the NetApp Console, select the menu image:workloads-menu-icon.png[The hamburger menu icon is used to navigate to workloads like storage, eda, ai, databases, vmware, and administration.] and then select *Storage*.
@@ -95,5 +132,17 @@ include::https://raw.githubusercontent.com/NetAppDocs/workload-fsx-ontap/main/_i
 //Rachel L: Added a hack to make the last step have a numbered step in the right order.
 . Select *Cut over*.
 
-.Result
-After cutover, the source volumes are deleted and the target volumes become read/write. You can link:https://docs.netapp.com/us-en/workload-fsx-ontap/change-tiering-policy.html[modify the tiering policy] for the target volume(s) after cutover.
+=== Update configuration settings after cutover 
+After you cut over replication for migration use cases, update the following storage VM configuration settings on the target storage VM. 
+
+* For iSCSI: 
+** Recreate the igroup 
+** Update LUN mapping 
+** Log in to each SAN client and update iSCSI/MPIO settings for the new target and remove the old vserver target IPs
+* Validate broadcast-domain MTU settings are as expected
+* Validate DNS settings are as expected
+* Recreate cache relationships (ONTAP FlexCache relationships) if there were cache volumes in the source storage VM.
+
+== Related information
+
+link:change-tiering-policy.html[Modify the tiering policy] for the target volume(s) after cutover.

--- a/use/task-replicate-data.adoc
+++ b/use/task-replicate-data.adoc
@@ -41,7 +41,7 @@ Workload Factory supports migration replication between the following storage sy
 ** First to first generation 
 ** Second to second generation
 
-To migrate storage VM data and configuration settings, you must complete two operations.
+To migrate storage VM data and configuration settings, you must complete three operations.
 
 1. <<Step 1: Create the replication relationship,Create the replication relationship>>, select *Migration* as the use case and select *Replicate storage VM configuration*.
 2. <<Step 2: Initialize the replication relationship,Initialize the replication relationship>> to transfer the data from the source to the target storage system.
@@ -132,7 +132,7 @@ Review these requirements before you begin.
 //Rachel L: Include content comes from the workload-fsx-ontap repository.
 include::https://raw.githubusercontent.com/NetAppDocs/workload-fsx-ontap/main/_include/cutover-replication.adoc[]
 
-[start=7]
+[start=6]
 //Rachel L: Added a hack to make the last step have a numbered step in the right order.
 . Select *Cut over*.
 


### PR DESCRIPTION
This pull request primarily updates documentation for Amazon FSx for NetApp ONTAP in the NetApp Console, with a focus on clarifying and improving instructions for replication and migration. The most significant change includes a complete rewrite and expansion of the replication and migration documentation.

**Replication and Migration Documentation Improvements:**

* The replication and migration workflow in `use/task-replicate-data.adoc` has been rewritten for clarity and detail. The process is now broken down into three explicit steps: creating the replication relationship, initializing it, and performing the cutover. Additional planning guidance, migration caveats, and post-cutover configuration steps have been added. [[1]](diffhunk://#diff-e91d5ea1b5abd39d8d44276b9a27448d372192d61a5d95092477813256a63ae7L4-R5) [[2]](diffhunk://#diff-e91d5ea1b5abd39d8d44276b9a27448d372192d61a5d95092477813256a63ae7L15-R50) [[3]](diffhunk://#diff-e91d5ea1b5abd39d8d44276b9a27448d372192d61a5d95092477813256a63ae7L77-R118) [[4]](diffhunk://#diff-e91d5ea1b5abd39d8d44276b9a27448d372192d61a5d95092477813256a63ae7R127-R152)

**Keyword and Metadata Standardization:**

* The term "BlueXP" has been removed from the `keywords` metadata in all relevant documentation files to standardize terminology and avoid confusion. [[1]](diffhunk://#diff-eeb91e423bf43be21fa638d740fc3019a84e78a15a5f858410a25042d111d6b6L6-R6) [[2]](diffhunk://#diff-6d88f866392dde7dab970456d2edcc6ba9352d4955ab8c70358ccdd06606388eL4-R4) [[3]](diffhunk://#diff-9d45fb38b5056352a6c44fcf4cd1d2d9aec04ea00561d6ca6e4439f70285ca89L4-R4) [[4]](diffhunk://#diff-5e03973a65f4def249061aa440c43329ecedd03fc4a5b9f1cefb83cccaf1c5bfL4-R4) [[5]](diffhunk://#diff-5f612f1b9e8b72d3b6092e05502bb86a567c9143e4d0b2f2b0643e0a15f45ae6L4-R4) [[6]](diffhunk://#diff-2b2d8b731f5afeec2c1023aff74e8dc2d0386c501e2afc5bcdd17f8ff41f73e6L4-R4) [[7]](diffhunk://#diff-efba745e1e2d62cd4fd13cb7a06b832860177d73978e45afe0ab8af562bbea80L4-R4) [[8]](diffhunk://#diff-ef660e0994fbec2f37293e0b362585ac4927fef75db52a65aa16c568f222608fL4-R4) [[9]](diffhunk://#diff-0ec501c8ce4b64279de79cc6f2255e07685cc8bb013c9591a303768b9c72c4abL4-R4) [[10]](diffhunk://#diff-518cf66c31f5ecbbc6eba14c00a6ead7f2bb98adedf4b9b3df483be415b5758dL4-R4)

**Documentation Link and Content Corrections:**

* Outdated references to BlueXP and old documentation URLs have been updated to point to the correct NetApp Console documentation.

**Summary and Metadata Updates:**

* Summaries and keywords have been updated in several files to better reflect current content, especially after the migration documentation rewrite. [[1]](diffhunk://#diff-e91d5ea1b5abd39d8d44276b9a27448d372192d61a5d95092477813256a63ae7L4-R5) [[2]](diffhunk://#diff-efba745e1e2d62cd4fd13cb7a06b832860177d73978e45afe0ab8af562bbea80L4-R4)

**Technical Clarifications and Additions:**

* Additional technical requirements and caveats have been added for migration cutover, such as port requirements and configuration settings that must be manually updated after migration.

These changes improve the clarity, accuracy, and consistency of the documentation for users managing FSx for ONTAP in the NetApp Console.